### PR TITLE
OPS-13888: prepare mcrouter for Ubuntu 22.04

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -it -v "${PWD}":/build  ubuntu:bionic-20200403 /build/docker_entry.sh
+docker run --rm -it -v "${PWD}":/build  ubuntu:jammy-20221101 /build/docker_entry.sh | tee build.log

--- a/docker_entry.sh
+++ b/docker_entry.sh
@@ -2,10 +2,10 @@
 # based of scripts in https://github.com/facebook/mcrouter/tree/master/mcrouter/scripts
 set -ex
 
-mcrouter_version="v2022.05.09.00"
-fb_zstd_version="v1.5.2"
-fmtlib_version="8.1.1"
-googletest_version="v1.10.x"
+mcrouter_version="v2023.02.13.00"
+fb_zstd_version="v1.5.4"
+fmtlib_version="9.1.0"
+googletest_version="v1.13.0"
 
 # limit the number of parallel compilation processes to avoid OOM crashes
 parallel_cap=4
@@ -35,7 +35,7 @@ apt-get install -y \
     g++ \
     gcc \
     git \
-    libboost1.65-all-dev \
+    libboost-all-dev \
     libbz2-dev \
     libdouble-conversion-dev \
     libevent-dev \
@@ -50,12 +50,16 @@ apt-get install -y \
     libsodium-dev \
     libssl-dev \
     libtool \
-    libunwind8-dev \
+    libunwind-dev \
     zlib1g-dev \
     make \
     pkg-config \
-    python-dev \
-    python-six \
+    python3-dev \
+    python-is-python3 \
+    python-dev-is-python3 \
+    python3-distutils \
+    python3-setuptools \
+    python3-six \
     dpkg-dev \
     debhelper \
     ragel \
@@ -79,7 +83,7 @@ function build_git {
 
   mkdir -p "${pkg_dir}/${build_dir}"
   pushd "${pkg_dir}/${build_dir}"
-  cmake_args="${cmake_extra} -DCMAKE_INSTALL_PREFIX=${install_dir} ${parallel}"
+  cmake_args="${cmake_extra} -DCMAKE_INSTALL_PREFIX=${install_dir}"
   CXXFLAGS="$CXXFLAGS ${cxxflags}" \
     LD_LIBRARY_PATH="$install_dir/lib:$LD_LIBRARY_PATH" \
     LD_RUN_PATH="$install_dir/lib:$LD_RUN_PATH" \
@@ -92,6 +96,8 @@ function build_git {
 function build_mcrouter {
   pushd "${pkg_dir}/mcrouter/mcrouter"
   autoreconf --install
+  # distutils is deprecated and the warning message breaks ./configure
+  sed -i 's/PYTHON -c /PYTHON -W ignore::DeprecationWarning -c /g' configure
   LD_LIBRARY_PATH="${install_dir}/lib:$LD_LIBRARY_PATH" \
     LD_RUN_PATH="${install_dir}/lib:$LD_RUN_PATH" \
     LDFLAGS="-L${install_dir}/lib $LDFLAGS" \

--- a/mcrouter/debian/changelog
+++ b/mcrouter/debian/changelog
@@ -1,3 +1,9 @@
+mcrouter (2023.02.16-1) jammy-fandom; urgency=medium
+
+  * Change the version to Ubuntu Jammy
+
+ -- Jacek Mech Wozniak <mech@fandom.com>  Thu, 16 Feb 2023 09:31:23 +0100
+
 mcrouter (2022.05.09-5) bionic-fandom; urgency=medium
 
   * Specify optimization flags for compilation


### PR DESCRIPTION
- build mcrouter inside the 22.04 container
- use newest packages
- switch to python3 build dependencies
- patch the `configure` script because FB still uses `distutils`